### PR TITLE
DEV-25552: Add werk task kill command to ops-cli

### DIFF
--- a/curalate-ops-cli.rb
+++ b/curalate-ops-cli.rb
@@ -2,9 +2,9 @@ class CuralateOpsCli < Formula
 
   desc "Curalate Ops Jobs CLI"
   homepage "https://github.com/curalate/curalate-ops-cli"
-  url "https://github.com/curalate/curalate-ops-cli/archive/0.0.24.tar.gz"
-  version "0.0.24"
-  sha256 "a784a66831f8f6d6341d3ddb0d337b8d573f56b362ccc5815000e63ddb54e8da"
+  url "https://github.com/curalate/curalate-ops-cli/archive/0.0.25.tar.gz"
+  version "0.0.25"
+  sha256 "49bac3754b2dfebaea8f5efe229face47437c7548f285731faf0217062e4b3a0"
 
   def install
 


### PR DESCRIPTION
Bump curalate-ops-cli dependency to 0.0.25